### PR TITLE
Update circe-yaml dependency version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val writer =
     .settings(
       name := "mergify-writer",
       libraryDependencies ++= Seq(
-        "io.circe"                     %% "circe-yaml"           % "0.14.1",
+        "io.circe"                     %% "circe-yaml"           % "1.15.0",
         "io.circe"                     %% "circe-generic-extras" % "0.14.3",
         "com.softwaremill.magnolia1_2" %% "magnolia"             % "1.1.9",
         "org.scala-lang"                % "scala-reflect"        % scalaVersion.value % Provided,


### PR DESCRIPTION
The version for the circe-yaml dependency in build.sbt has been updated from 0.14.1 to 1.15.0. This change ensures the project is using the latest stable version of circe-yaml dependency.
